### PR TITLE
Added Widestring edit

### DIFF
--- a/moddingSuite/App.xaml
+++ b/moddingSuite/App.xaml
@@ -99,6 +99,9 @@
         <DataTemplate x:Key="GuidEditingTemplate">
             <ValueEditing:GuidEditingTemplate />
         </DataTemplate>
+        <DataTemplate x:Key="WideStringEditingTemplate">
+            <ValueEditing:WideStringEditingTemplate />
+        </DataTemplate>
         <DataTemplate x:Key="BooleanEditingTemplate">
             <ValueEditing:BooleanEditingTemplate />
         </DataTemplate>
@@ -110,7 +113,6 @@
         <DataTemplate x:Key="MapEditingTemplate">
             <ValueEditing:MapEditingTemplate />
         </DataTemplate>
-
 
         <DataTemplate x:Key="StringTableEditingTemplate">
             <ValueEditing:StringTableEditingTemplate />

--- a/moddingSuite/Model/Ndfbin/NdfPropertyValue.cs
+++ b/moddingSuite/Model/Ndfbin/NdfPropertyValue.cs
@@ -180,9 +180,11 @@ namespace moddingSuite.Model.Ndfbin
 
             var newVal = Value.GetBytes();
 
+            if (newVal == null) return;
+
             if (newVal != null && _oldVal != null && Utils.ByteArrayCompare(newVal, _oldVal))
                 return;
-
+            
             ChangeEntryBase change = null;
 
             switch (Value.Type)

--- a/moddingSuite/Model/Ndfbin/Types/AllTypes/NdfObjectReference.cs
+++ b/moddingSuite/Model/Ndfbin/Types/AllTypes/NdfObjectReference.cs
@@ -25,7 +25,11 @@ namespace moddingSuite.Model.Ndfbin.Types.AllTypes
             set
             {
                 _class = value;
-                OnPropertyChanged("Class");
+
+                if (value != null)
+                {
+                    OnPropertyChanged("Class");
+                }
             }
         }
 
@@ -70,6 +74,8 @@ namespace moddingSuite.Model.Ndfbin.Types.AllTypes
         public override byte[] GetBytes()
         {
             var refereceData = new List<byte>();
+
+            if (Class == null) { return null; }
 
             refereceData.AddRange(BitConverter.GetBytes(InstanceId));
 

--- a/moddingSuite/View/Extension/EditingControlDataTemplateSelector.cs
+++ b/moddingSuite/View/Extension/EditingControlDataTemplateSelector.cs
@@ -41,10 +41,10 @@ namespace moddingSuite.View.Extension
 
                 case NdfType.Color32:
                     return element.FindResource("ColorPickerEditingTemplate") as DataTemplate;
-
+                case NdfType.WideString:
+                    return element.FindResource("WideStringEditingTemplate") as DataTemplate;
                 case NdfType.Vector:
                     return element.FindResource("VectorEditingTemplate") as DataTemplate;
-                    
 
                 case NdfType.Map:
                     return element.FindResource("MapEditingTemplate") as DataTemplate;

--- a/moddingSuite/View/Ndfbin/NdfbinView.xaml
+++ b/moddingSuite/View/Ndfbin/NdfbinView.xaml
@@ -126,8 +126,11 @@
                                     Width="150"
                                     Margin="5"
                                     VerticalAlignment="Top"
-                                    Text="{Binding Path=ClassesFilterExpression, UpdateSourceTrigger=PropertyChanged}"
-                                    TextChanged="TextBox_TextChanged"/>
+                                    TextChanged="TextBox_TextChanged">
+                                    <TextBox.Text>
+                                        <Binding Path="ClassesFilterExpression" UpdateSourceTrigger="PropertyChanged" Delay="500"></Binding>
+                                    </TextBox.Text>
+                                </TextBox>
 
                                 <Button Command="{Binding MakeTopObjectCommand}" ToolTip="Make top object">
                                     <Image SnapsToDevicePixels="True" Source="{StaticResource ImportIcon}" />

--- a/moddingSuite/View/Ndfbin/NdfbinView.xaml.cs
+++ b/moddingSuite/View/Ndfbin/NdfbinView.xaml.cs
@@ -14,12 +14,21 @@ namespace moddingSuite.View.Ndfbin
 
         private void TextBox_TextChanged(object sender, System.Windows.Controls.TextChangedEventArgs e)
         {
-            //selects the top class if there are classes to select to avoid having nothing selected
-            if (classGrid.Items.Count > 0) 
+
+            try
             {
-                classGrid.SelectedItem = classGrid.Items[0];
+                //selects the top class if there are classes to select to avoid having nothing selected
+                if (classGrid.Items.Count > 0)
+                {
+                    classGrid.SelectedItem = classGrid.Items[0];
+                }
+                SetInstanceGridItem();
             }
-            SetInstanceGridItem();
+            catch (System.Exception)
+            {
+
+                throw new System.Exception("fout in roemers code");
+            }
         }
 
         private void classGrid_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
@@ -28,14 +37,22 @@ namespace moddingSuite.View.Ndfbin
         }
         private void SetInstanceGridItem()
         {
-            // scrolls to currently selected instance
-            if (instanceGrid.Items.Count == 0)
+            try
             {
-                return;
+                // scrolls to currently selected instance
+                if (instanceGrid.Items == null || instanceGrid.Items.Count == 0)
+                {
+                    return;
+                }
+                instanceGrid.ScrollIntoView(instanceGrid.Items[instanceGrid.Items.Count - 1]);
+                instanceGrid.UpdateLayout();
+                instanceGrid.ScrollIntoView(instanceGrid.SelectedItem);
             }
-            instanceGrid.ScrollIntoView(instanceGrid.Items[instanceGrid.Items.Count - 1]);
-            instanceGrid.UpdateLayout();
-            instanceGrid.ScrollIntoView(instanceGrid.SelectedItem);
+            catch (System.Exception)
+            {
+
+                throw new System.Exception("fout in roemers code 2");
+            }
         }
     }
 }

--- a/moddingSuite/View/Ndfbin/ValueEditing/WideStringEditingTemplate.xaml
+++ b/moddingSuite/View/Ndfbin/ValueEditing/WideStringEditingTemplate.xaml
@@ -1,0 +1,11 @@
+﻿<UserControl x:Class="moddingSuite.View.Ndfbin.ValueEditing.WideStringEditingTemplate"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:Extension1="clr-namespace:moddingSuite.View.Extension" mc:Ignorable="d" 
+             d:DesignHeight="300" d:DesignWidth="300">
+    <Grid>
+        <TextBox Text="{Binding Path=Value.Value}" />
+    </Grid>
+</UserControl>

--- a/moddingSuite/View/Ndfbin/ValueEditing/WideStringEditingTemplate.xaml.cs
+++ b/moddingSuite/View/Ndfbin/ValueEditing/WideStringEditingTemplate.xaml.cs
@@ -1,0 +1,15 @@
+﻿using System.Windows.Controls;
+
+namespace moddingSuite.View.Ndfbin.ValueEditing
+{
+    /// <summary>
+    /// Interaction logic for WideStringEditingTemplate.xaml
+    /// </summary>
+    public partial class WideStringEditingTemplate : UserControl
+    {
+        public WideStringEditingTemplate()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/moddingSuite/ViewModel/Ndf/ListEditorViewModel.cs
+++ b/moddingSuite/ViewModel/Ndf/ListEditorViewModel.cs
@@ -95,24 +95,24 @@ namespace moddingSuite.ViewModel.Ndf
 
             if (cv == null)
                 return;
+            
+            if (cv.CurrentItem == null)
+                return;
 
             NdfType type =
                 Value.GroupBy(x => x.Value.Type).OrderByDescending(gp => gp.Count()).Select(x => x.First().Value.Type).
                     Single();
+            var val = cv.CurrentItem as CollectionItemValueHolder;
+            
+            //old method
+            //var wrapper =
+               // new CollectionItemValueHolder(NdfTypeManager.GetValue(new byte[NdfTypeManager.SizeofType(type)], type, NdfbinManager), NdfbinManager);
 
             var wrapper =
-                new CollectionItemValueHolder(NdfTypeManager.GetValue(new byte[NdfTypeManager.SizeofType(type)], type, NdfbinManager), NdfbinManager);
+                new CollectionItemValueHolder(val.Value, NdfbinManager);
 
             if (IsInsertMode)
             {
-                if (cv.CurrentItem == null)
-                    return;
-
-                var val = cv.CurrentItem as CollectionItemValueHolder;
-
-                if (val == null)
-                    return;
-
                 Value.Insert(cv.CurrentPosition + 1, wrapper);
             }
             else

--- a/moddingSuite/ViewModel/Ndf/NdfObjectViewModel.cs
+++ b/moddingSuite/ViewModel/Ndf/NdfObjectViewModel.cs
@@ -5,6 +5,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Input;
+using IronPython.Runtime.Operations;
 using moddingSuite.Model.Ndfbin;
 using moddingSuite.Model.Ndfbin.Types;
 using moddingSuite.Model.Ndfbin.Types.AllTypes;
@@ -139,14 +140,20 @@ namespace moddingSuite.ViewModel.Ndf
         private void CopyToInstancesExecute(object obj)
         {
             var cv = CollectionViewSource.GetDefaultView(PropertyValues);
+            var result = MessageBox.Show("Do you want to copy this instance value to ALL other instances? If unsure, press no", "Confirmation",
+                MessageBoxButton.YesNo, MessageBoxImage.Question,defaultResult: MessageBoxResult.No);
 
-            var item = cv.CurrentItem as NdfPropertyValue;
-            foreach (var instance in item.Instance.Class.Instances)
+            if (result == MessageBoxResult.Yes)
             {
-                var property = instance.PropertyValues.First(x => x.Property == item.Property);
-                property.BeginEdit();
-                property.Value = item.Value;
-                property.EndEdit();
+                var item = cv.CurrentItem as NdfPropertyValue;
+
+                foreach (var instance in item.Instance.Class.Instances)
+                {
+                    var property = instance.PropertyValues.First(x => x.Property == item.Property);
+                    property.BeginEdit();
+                    property.Value = item.Value;
+                    property.EndEdit();
+                }
             }
         }
 


### PR DESCRIPTION
Objectrefence copy now copies class
Making typo in objectreference search now no longer throws exception, and can research as long as you dont click away while an incorrect class is in